### PR TITLE
Command execution mode: shell / exec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "ya-runtime-dbg"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-runtime-dbg"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 repository = "https://github.com/golemfactory/ya-runtime-dbg"

--- a/README.md
+++ b/README.md
@@ -15,21 +15,25 @@ Check the [releases](https://github.com/golemfactory/ya-runtime-dbg/releases) pa
 
 ```bash
 USAGE:
-ya-runtime-dbg [FLAGS] [OPTIONS] --runtime <runtime> --task-package <task-package> --workdir <workdir> [varargs]...
+    ya-runtime-dbg [FLAGS] [OPTIONS] --runtime <runtime> --task-package <task-package> --workdir <workdir> [varargs]...
 
 FLAGS:
---no-deploy    Skip deployment phase
--h, --help         Prints help information
--V, --version      Prints version information
+        --no-deploy    Skip deployment phase
+    -h, --help         Prints help information
+    -V, --version      Prints version information
 
 OPTIONS:
--r, --runtime <runtime>              Runtime binary
--w, --workdir <workdir>              Working directory
--t, --task-package <task-package>    Task package to deploy (e.g. gvmi)
--p, --protocol <protocol>            Service protocol version [default: 0.1.0]
+        --exec-mode <exec-mode>          Mode to execute commands in [default: shell]  [possible values:
+                                         Shell, Exec]
+        --exec-shell <exec-shell>        Execution shell (for "--exec-mode shell" or default mode) [default:
+                                         bash]
+    -r, --runtime <runtime>              Runtime binary
+    -w, --workdir <workdir>              Working directory
+    -t, --task-package <task-package>    Task package to deploy
+    -p, --protocol <protocol>            Service protocol version [default: 0.1.0]
 
 ARGS:
-<varargs>...    Additional runtime arguments
+    <varargs>...    Additional runtime arguments
 ```
 
 ## Example invocation
@@ -43,4 +47,4 @@ ya-runtime-dbg --runtime /usr/lib/yagna/plugins/ya-runtime-vm/ya-runtime-vm \
 
 ## Available runtimes
 
-Available runtimes be discovered via [ya-runtime](https://github.com/topics/ya-runtime) topic on GH.
+Available runtimes can be discovered via [ya-runtime](https://github.com/topics/ya-runtime) topic on GH.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13,8 +13,8 @@ lazy_static::lazy_static! {
     pub static ref COLOR_PROMPT: ansi_term::Style = ansi_term::Color::Green.bold();
 }
 
-pub fn default_ui<P: AsRef<Path>>(history_path: P) -> Result<UI<DefaultTerminal>> {
-    UI::new(Interface::new("ui")?, history_path)
+pub fn ui<P: AsRef<Path>>(history_path: P, shell: &str) -> Result<UI<DefaultTerminal>> {
+    UI::new(Interface::new("ui")?, history_path, shell)
 }
 
 macro_rules! ui_info {
@@ -58,7 +58,11 @@ impl<T: Terminal> Clone for UI<T> {
 }
 
 impl<T: Terminal + 'static> UI<T> {
-    pub fn new<P: AsRef<Path>>(interface: Interface<T>, history_path: P) -> Result<Self> {
+    pub fn new<P: AsRef<Path>>(
+        interface: Interface<T>,
+        history_path: P,
+        shell: &str,
+    ) -> Result<Self> {
         {
             OpenOptions::new()
                 .append(true)
@@ -69,8 +73,9 @@ impl<T: Terminal + 'static> UI<T> {
 
         interface.load_history(&history_path)?;
         interface.set_prompt(&format!(
-            "\x01{prefix}\x02{text}\x01{suffix}\x02",
+            "\x01{prefix}\x02{shell} {text}\x01{suffix}\x02",
             prefix = (*COLOR_PROMPT).prefix(),
+            shell = shell,
             text = "▶ ",
             suffix = (*COLOR_PROMPT).suffix()
         ))?;


### PR DESCRIPTION
Adds 2 command line arguments:

- `--exec-mode [exec | shell]` for executing commands in raw / shell mode (default: `shell`)
- `--exec-shell <shell>` for specifying the shell in "shell mode" (default: `bash`)

Resolves #2 